### PR TITLE
Method to explicitly check if member exists in json file

### DIFF
--- a/JsonConfig/ConfigObjects.cs
+++ b/JsonConfig/ConfigObjects.cs
@@ -85,10 +85,10 @@ namespace JsonConfig
 				result = this.Clone ();
 				return true;
 			}
-            if (binder.Name == "Exists" && args.Length == 1 && args[0] is string) {
-                result = members.ContainsKey ((string) args[0]);
-                return true;
-            }
+			if (binder.Name == "Exists" && args.Length == 1 && args[0] is string) {
+				result = members.ContainsKey ((string) args[0]);
+				return true;
+			}
 
 			// no other methods availabe, error
 			result = null;


### PR DESCRIPTION
This allows you to explicitly check if a member exists in a json file. Especially useful for checking if an array (such as string[], etc..) actually exists instead of dealing with an empty array unknowing if it actually is defined in the configuration file or not
