### PR TITLE
JSON.Net - Initial support

### DIFF
--- a/JsonConfig.Tests/InvalidJson.cs
+++ b/JsonConfig.Tests/InvalidJson.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using NUnit.Framework;
 
 namespace JsonConfig.Tests
@@ -7,14 +8,14 @@ namespace JsonConfig.Tests
 	public class InvalidJson
 	{
 		[Test]
-		[ExpectedException (typeof(JsonFx.Serialization.DeserializationException))]
+        [ExpectedException(typeof(InvalidDataException))]
 		public void EvidentlyInvalidJson ()
 		{
 			dynamic scope = Config.Global;
 			scope.ApplyJson ("jibberisch");
 		}
 		[Test]
-		[ExpectedException (typeof(JsonFx.Serialization.DeserializationException))]
+        [ExpectedException(typeof(InvalidDataException))]
 		public void MissingObjectIdentifier()
 		{	
 			dynamic scope = Config.Global;

--- a/JsonConfig/ConfigObjects.cs
+++ b/JsonConfig/ConfigObjects.cs
@@ -100,8 +100,13 @@ namespace JsonConfig
 		}
 		public override string ToString ()
 		{
+            // TODO: Cleanup JsonFx switch
+#if !USE_JSON_NET
 			var w = new JsonFx.Json.JsonWriter ();
 			return w.Write (this.members);
+#else
+            return Newtonsoft.Json.JsonConvert.SerializeObject(this.members);
+#endif
 		}
 		public void ApplyJson (string json)
 		{

--- a/JsonConfig/JsonConfig.csproj
+++ b/JsonConfig/JsonConfig.csproj
@@ -37,11 +37,16 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>USE_JSON_NET_NO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="JsonFx, Version=2.0.1209.2802, Culture=neutral, PublicKeyToken=315052dd637f8a52, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/JsonConfig/Merger.cs
+++ b/JsonConfig/Merger.cs
@@ -162,6 +162,8 @@ namespace JsonConfig
 			var obj1_type = obj1.GetType ().GetElementType ();
 			if (obj1_type == typeof (ConfigObject)) 
 				return x.ToArray (typeof(ConfigObject));
+            else if (obj1_type == null) // Kludge for JSON.Net since it doesn't return embedded objects as ExpandoObjects
+                return x.ToArray(typeof(object));
 			else
 				return x.ToArray (obj1_type);
 		}

--- a/JsonConfig/packages.config
+++ b/JsonConfig/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Add compile time option (USE_JSON_NET) to use JSON.Net instead of
JsonFx.  25 of 31 unit tests pass (primarily, the tests that deal with nested objects/arrays fail because JSON.Net won't return these as ExpandoObjects).
