### PR TITLE
Replaced JsonFX with Json.NET

### DIFF
--- a/JsonConfig.Tests/Basic.cs
+++ b/JsonConfig.Tests/Basic.cs
@@ -1,6 +1,5 @@
 using System;
 using NUnit.Framework;
-using JsonFx.Json;
 using System.Reflection;
 using System.IO;
 using System.Collections.Generic;

--- a/JsonConfig.Tests/InvalidJson.cs
+++ b/JsonConfig.Tests/InvalidJson.cs
@@ -7,14 +7,14 @@ namespace JsonConfig.Tests
 	public class InvalidJson
 	{
 		[Test]
-		[ExpectedException (typeof(JsonFx.Serialization.DeserializationException))]
+		[ExpectedException (typeof(Newtonsoft.Json.JsonReaderException))]
 		public void EvidentlyInvalidJson ()
 		{
 			dynamic scope = Config.Global;
 			scope.ApplyJson ("jibberisch");
 		}
 		[Test]
-		[ExpectedException (typeof(JsonFx.Serialization.DeserializationException))]
+		[ExpectedException(typeof(Newtonsoft.Json.JsonReaderException))]
 		public void MissingObjectIdentifier()
 		{	
 			dynamic scope = Config.Global;

--- a/JsonConfig.Tests/JsonConfig.Tests.csproj
+++ b/JsonConfig.Tests/JsonConfig.Tests.csproj
@@ -29,9 +29,9 @@
     <ConsolePause>False</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JsonFx, Version=2.0.1209.2802, Culture=neutral, PublicKeyToken=315052dd637f8a52, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/JsonConfig.Tests/Main.cs
+++ b/JsonConfig.Tests/Main.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using JsonFx.Json;
 
 using JsonConfig;
 using System.Net;

--- a/JsonConfig.Tests/Tests.cs
+++ b/JsonConfig.Tests/Tests.cs
@@ -4,7 +4,6 @@ using System.Dynamic;
 using System.Linq;
 using Microsoft.CSharp;
 
-using JsonFx;
 using NUnit.Framework;
 using JsonConfig;
 using System.Reflection;

--- a/JsonConfig.Tests/TypeTests.cs
+++ b/JsonConfig.Tests/TypeTests.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace JsonConfig.Tests
 {
@@ -42,10 +44,9 @@ namespace JsonConfig.Tests
 			var name = "Types";
 			var jsonTests = Assembly.GetExecutingAssembly ().GetManifestResourceStream ("JsonConfig.Tests.JSON." + name + ".json");
 			var sReader = new StreamReader (jsonTests);
-			var jReader = new JsonFx.Json.JsonReader ();
-			dynamic parsed = jReader.Read (sReader.ReadToEnd ());
+			dynamic parsed = JsonConvert.DeserializeObject<ExpandoObject>(sReader.ReadToEnd (), new ExpandoObjectConverter());
 
-			dynamic config = ConfigObject.FromExpando (parsed);
+			dynamic config = ConfigObject.FromExpando (JsonNetAdapter.Transform(parsed));
 
 			Assert.AreEqual ("bar", config.Foo);
 			Assert.AreEqual ("bar", ((ICollection<dynamic>) config.NestedArray).First ().Foo);

--- a/JsonConfig.Tests/packages.config
+++ b/JsonConfig.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JsonFx" version="2.0.1209.2802" targetFramework="net40" />
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
+  <package id="NUnit" version="2.6.3" targetFramework="net4" />
 </packages>

--- a/JsonConfig/Config.cs
+++ b/JsonConfig/Config.cs
@@ -27,9 +27,9 @@ using System.Dynamic;
 using System.Reflection;
 using System.IO;
 
-using JsonFx;
-using JsonFx.Json;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace JsonConfig 
 {
@@ -216,10 +216,13 @@ namespace JsonConfig
 			
 			var filtered_json = string.Join ("\n", filtered);
 			
-			var json_reader = new JsonReader ();
-			dynamic parsed = json_reader.Read (filtered_json);
+			var parsed = JsonConvert.DeserializeObject<ExpandoObject> (filtered_json, new ExpandoObjectConverter());
+
+			// transform the ExpandoObject to the format expected by ConfigObject
+			parsed = JsonNetAdapter.Transform(parsed);
+
 			// convert the ExpandoObject to ConfigObject before returning
-            		var result = ConfigObject.FromExpando(parsed);
+			var result = ConfigObject.FromExpando(parsed);
 			return result;
 		}
 		// overrides any default config specified in default.conf

--- a/JsonConfig/ConfigObjects.cs
+++ b/JsonConfig/ConfigObjects.cs
@@ -24,6 +24,7 @@ using System;
 using System.Dynamic;
 using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json;
 
 namespace JsonConfig
 {
@@ -100,8 +101,7 @@ namespace JsonConfig
 		}
 		public override string ToString ()
 		{
-			var w = new JsonFx.Json.JsonWriter ();
-			return w.Write (this.members);
+			return JsonConvert.SerializeObject(this.members);
 		}
 		public void ApplyJson (string json)
 		{

--- a/JsonConfig/JsonConfig.csproj
+++ b/JsonConfig/JsonConfig.csproj
@@ -38,27 +38,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">		
-      <OutputPath>bin\Release\</OutputPath>		
-      <DebugType>pdbonly</DebugType>		
-      <DebugSymbols>true</DebugSymbols>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JsonFx, Version=2.0.1209.2802, Culture=neutral, PublicKeyToken=315052dd637f8a52, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="JsonFx">
-      <HintPath>..\lib\JsonFx.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="JsonNetAdapter.cs" />
     <Compile Include="JsonConfigExtensions.cs" />
     <Compile Include="Merger.cs" />
     <Compile Include="Config.cs" />

--- a/JsonConfig/JsonNetAdapter.cs
+++ b/JsonConfig/JsonNetAdapter.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+
+namespace JsonConfig
+{
+    public static class JsonNetAdapter
+    {
+        public static ExpandoObject Transform(ExpandoObject data)
+        {
+            var newExpando = new ExpandoObject();
+
+            var edict = (IDictionary<string, object>)newExpando;
+
+            foreach (var kvp in data)
+            {
+                if (kvp.Value is ExpandoObject)
+                {
+                    edict[kvp.Key] = Transform((ExpandoObject)kvp.Value);
+                }
+                else if (kvp.Value is List<object>)
+                {
+                    var result = ConvertList((List<object>)kvp.Value);
+
+                    if (result.GetType().GetElementType() == typeof(ExpandoObject))
+                    {
+                        var expandoArray = (ExpandoObject[])result;
+
+                        for (var i = 0; i < expandoArray.Length; i++)
+                        {
+                            expandoArray[i] = Transform(expandoArray[i]);
+                        }
+                    }
+
+                    edict[kvp.Key] = result;
+                }
+                else
+                {
+                    edict[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return newExpando;
+        }
+
+        private static object ConvertList(List<object> list)
+        {
+            var hasSingleType = true;
+
+            ArrayList tList = new ArrayList(list.Count);
+
+            Type listType = null;
+
+            if (list.Count > 0)
+            {
+                listType = list.First().GetType();
+            }
+
+            foreach (var v in list)
+            {
+                hasSingleType = hasSingleType && listType == v.GetType();
+                tList.Add(v);
+            }
+
+            return tList.ToArray(hasSingleType && listType != null ? listType : typeof(object));
+        }
+    }
+}

--- a/JsonConfig/JsonNetAdapter.cs
+++ b/JsonConfig/JsonNetAdapter.cs
@@ -16,33 +16,25 @@ namespace JsonConfig
 
             foreach (var kvp in data)
             {
-                if (kvp.Value is ExpandoObject)
-                {
-                    edict[kvp.Key] = Transform((ExpandoObject)kvp.Value);
-                }
-                else if (kvp.Value is List<object>)
-                {
-                    var result = ConvertList((List<object>)kvp.Value);
-
-                    if (result.GetType().GetElementType() == typeof(ExpandoObject))
-                    {
-                        var expandoArray = (ExpandoObject[])result;
-
-                        for (var i = 0; i < expandoArray.Length; i++)
-                        {
-                            expandoArray[i] = Transform(expandoArray[i]);
-                        }
-                    }
-
-                    edict[kvp.Key] = result;
-                }
-                else
-                {
-                    edict[kvp.Key] = kvp.Value;
-                }
+                edict[kvp.Key] = TransformByType(kvp.Value);
             }
 
             return newExpando;
+        }
+
+        private static object TransformByType(object value)
+        {
+            if (value is ExpandoObject)
+            {
+                return Transform((ExpandoObject)value);
+            }
+
+            if (value is List<object>)
+            {
+                return ConvertList((List<object>)value);
+            }
+
+            return value;
         }
 
         private static object ConvertList(List<object> list)
@@ -61,7 +53,7 @@ namespace JsonConfig
             foreach (var v in list)
             {
                 hasSingleType = hasSingleType && listType == v.GetType();
-                tList.Add(v);
+                tList.Add(TransformByType(v));
             }
 
             return tList.ToArray(hasSingleType && listType != null ? listType : typeof(object));

--- a/JsonConfig/packages.config
+++ b/JsonConfig/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JsonFx" version="2.0.1209.2802" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
Created a new class that correctly transforms an ExpandoObject  parsed by Json.NET into an ExpandoObject as expected by ConfigObjects.
Specifically the transformation removes all List<object> and replaces them with an array of the correct type (if all elements are the same type) or object[] if not.
